### PR TITLE
Fix issue with OpenNLP phrase chunking

### DIFF
--- a/annot8-components-opennlp/pom.xml
+++ b/annot8-components-opennlp/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>annot8-components-opennlp</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <name>Annot8 OpenNLP Components</name>
     <description>Components to work with language features within text (e.g. tokenization, parts of speech) using OpenNLP</description>
 

--- a/annot8-components-opennlp/src/main/java/io/annot8/components/opennlp/processors/PhraseChunks.java
+++ b/annot8-components-opennlp/src/main/java/io/annot8/components/opennlp/processors/PhraseChunks.java
@@ -161,7 +161,11 @@ public class PhraseChunks
                                   .getBounds(SpanBounds.class)
                                   .get()
                                   .getBegin(),
-                              tokens.get(span.getEnd()).getBounds(SpanBounds.class).get().getEnd())
+                              tokens
+                                  .get(span.getEnd() - 1)
+                                  .getBounds(SpanBounds.class)
+                                  .get()
+                                  .getEnd())
                           .filter(
                               a -> AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN.equals(a.getType()))
                           .collect(Collectors.toList());

--- a/annot8-components-opennlp/src/test/java/io/annot8/components/opennlp/processors/LanguageFeaturesTest.java
+++ b/annot8-components-opennlp/src/test/java/io/annot8/components/opennlp/processors/LanguageFeaturesTest.java
@@ -88,6 +88,6 @@ public class LanguageFeaturesTest {
                         .collect(Collectors.joining(" ")))
             .collect(Collectors.toList());
 
-    assertTrue(phrases.contains("some text ."));
+    assertTrue(phrases.contains("some text"));
   }
 }

--- a/annot8-components-opennlp/src/test/java/io/annot8/components/opennlp/processors/PhraseChunksTest.java
+++ b/annot8-components-opennlp/src/test/java/io/annot8/components/opennlp/processors/PhraseChunksTest.java
@@ -1,20 +1,30 @@
 /* Annot8 (annot8.io) - Licensed under Apache-2.0. */
 package io.annot8.components.opennlp.processors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.annot8.api.annotations.Annotation;
 import io.annot8.api.components.Processor;
+import io.annot8.api.data.Content;
 import io.annot8.api.data.Item;
+import io.annot8.api.references.AnnotationReference;
 import io.annot8.common.data.bounds.SpanBounds;
 import io.annot8.conventions.AnnotationTypes;
 import io.annot8.conventions.PropertyKeys;
 import io.annot8.testing.testimpl.TestItem;
 import io.annot8.testing.testimpl.content.TestStringContent;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public class PhraseChunksTest {
   @Test
   public void test() {
+    // Note, this test doesn't test for the correct result,
+    // but just checks that a result is produced without an exception being through.
+    // The testOpenNLPExample() does check for the correct result
+
     Item item = new TestItem();
     TestStringContent content =
         item.createContent(TestStringContent.class)
@@ -27,69 +37,15 @@ public class PhraseChunksTest {
         .withType(AnnotationTypes.ANNOTATION_TYPE_SENTENCE)
         .withBounds(new SpanBounds(0, 36))
         .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(0, 4))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "JJ")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(5, 9))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "NN")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(9, 10))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, ",")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(11, 14))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "NNP")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(15, 21))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "NNP")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(22, 25))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "VBD")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(26, 28))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "IN")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(29, 35))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "NNP")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(35, 36))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, ".")
-        .save();
+    createWordToken(content, 0, 4, "JJ");
+    createWordToken(content, 5, 9, "NN");
+    createWordToken(content, 9, 10, ",");
+    createWordToken(content, 11, 14, "NNP");
+    createWordToken(content, 15, 21, "NNP");
+    createWordToken(content, 22, 25, "VBD");
+    createWordToken(content, 26, 28, "IN");
+    createWordToken(content, 29, 35, "NNP");
+    createWordToken(content, 35, 36, ".");
 
     content
         .getAnnotations()
@@ -97,62 +53,14 @@ public class PhraseChunksTest {
         .withType(AnnotationTypes.ANNOTATION_TYPE_SENTENCE)
         .withBounds(new SpanBounds(37, 70))
         .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(37, 40))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "NNP")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(41, 44))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "VBD")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(45, 49))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "VBN")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(50, 57))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "VBG")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(58, 60))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "TO")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(61, 65))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "NNP")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(66, 69))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, "NNP")
-        .save();
-    content
-        .getAnnotations()
-        .create()
-        .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
-        .withBounds(new SpanBounds(69, 70))
-        .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, ".")
-        .save();
+    createWordToken(content, 37, 40, "NNP");
+    createWordToken(content, 41, 44, "VBD");
+    createWordToken(content, 45, 49, "VBN");
+    createWordToken(content, 50, 57, "VBG");
+    createWordToken(content, 58, 60, "TO");
+    createWordToken(content, 61, 65, "NNP");
+    createWordToken(content, 66, 69, "NNP");
+    createWordToken(content, 69, 70, ".");
 
     PhraseChunks desc = new PhraseChunks();
     Processor p = desc.createComponent(null, new PhraseChunks.Settings());
@@ -161,5 +69,89 @@ public class PhraseChunksTest {
     assertTrue(item.getGroups().getAll().count() > 0);
 
     p.close();
+  }
+
+  @Test
+  public void testOpenNLPExample() {
+    // Example taken from:
+    // http://opennlp.apache.org/docs/1.9.3/manual/opennlp.html#tools.parser.chunking.cmdline
+
+    Item item = new TestItem();
+    TestStringContent content =
+        item.createContent(TestStringContent.class)
+            .withData(
+                "Rockwell said the agreement calls for it to supply 200 additional so-called shipsets for the planes.")
+            .save();
+
+    String rockwell = createWordToken(content, 0, 8, "NNP");
+    String said = createWordToken(content, 9, 13, "VBD");
+    String the1 = createWordToken(content, 14, 17, "DT");
+    String agreement = createWordToken(content, 18, 27, "NN");
+    String calls = createWordToken(content, 28, 33, "VBZ");
+    String for1 = createWordToken(content, 34, 37, "IN");
+    String it = createWordToken(content, 38, 40, "PRP");
+    String to = createWordToken(content, 41, 43, "TO");
+    String supply = createWordToken(content, 44, 50, "VB");
+    String num200 = createWordToken(content, 51, 54, "CD");
+    String additional = createWordToken(content, 55, 65, "JJ");
+    String soCalled = createWordToken(content, 66, 75, "JJ");
+    String shipsets = createWordToken(content, 76, 84, "NNS");
+    String for2 = createWordToken(content, 85, 88, "IN");
+    String the2 = createWordToken(content, 89, 92, "DT");
+    String planes = createWordToken(content, 93, 99, "NNS");
+    createWordToken(content, 99, 100, ".");
+
+    content
+        .getAnnotations()
+        .create()
+        .withType(AnnotationTypes.ANNOTATION_TYPE_SENTENCE)
+        .withBounds(new SpanBounds(0, 100))
+        .save();
+
+    PhraseChunks desc = new PhraseChunks();
+    Processor p = desc.createComponent(null, new PhraseChunks.Settings());
+    p.process(item);
+
+    List<List<String>> expectedChunks =
+        List.of(
+            List.of(rockwell),
+            List.of(said),
+            List.of(the1, agreement),
+            List.of(calls),
+            List.of(for1),
+            List.of(it),
+            List.of(to, supply),
+            List.of(num200, additional, soCalled, shipsets),
+            List.of(for2),
+            List.of(the2, planes));
+
+    List<List<String>> actualChunks =
+        item.getGroups()
+            .getAll()
+            .map(
+                g ->
+                    g.getReferences().values().stream()
+                        .flatMap(i -> i)
+                        .map(AnnotationReference::getAnnotationId)
+                        .collect(Collectors.toList()))
+            .collect(Collectors.toList());
+
+    assertEquals(expectedChunks.size(), actualChunks.size());
+    expectedChunks.forEach(e -> assertTrue(actualChunks.stream().anyMatch(e::containsAll)));
+
+    p.close();
+  }
+
+  private String createWordToken(Content<?> content, int begin, int end, String pos) {
+    Annotation a =
+        content
+            .getAnnotations()
+            .create()
+            .withType(AnnotationTypes.ANNOTATION_TYPE_WORDTOKEN)
+            .withBounds(new SpanBounds(begin, end))
+            .withProperty(PropertyKeys.PROPERTY_KEY_PARTOFSPEECH, pos)
+            .save();
+
+    return a.getId();
   }
 }


### PR DESCRIPTION
The OpenNLP Phrase Chunking was adding an additional token to each chunk, because the Span returned was being treated as inclusive rather than exclusive.

This is now fixed, with a more comprehensive unit test in place to catch this.