### PR TITLE
Fix bug with American date processing

### DIFF
--- a/annot8-components-temporal/pom.xml
+++ b/annot8-components-temporal/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>annot8-components-temporal</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <name>Annot8 Temporal Components</name>
   <description>Annot8 processors focussing on time and date information</description>
 

--- a/annot8-components-temporal/src/main/java/io/annot8/components/temporal/processors/Date.java
+++ b/annot8-components-temporal/src/main/java/io/annot8/components/temporal/processors/Date.java
@@ -15,7 +15,6 @@ import io.annot8.components.base.text.processors.AbstractTextProcessor;
 import io.annot8.components.temporal.processors.utils.DateTimeUtils;
 import io.annot8.conventions.AnnotationTypes;
 import io.annot8.conventions.PropertyKeys;
-
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.Year;

--- a/annot8-components-temporal/src/main/java/io/annot8/components/temporal/processors/Date.java
+++ b/annot8-components-temporal/src/main/java/io/annot8/components/temporal/processors/Date.java
@@ -15,6 +15,7 @@ import io.annot8.components.base.text.processors.AbstractTextProcessor;
 import io.annot8.components.temporal.processors.utils.DateTimeUtils;
 import io.annot8.conventions.AnnotationTypes;
 import io.annot8.conventions.PropertyKeys;
+
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.Year;
@@ -24,10 +25,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-@ComponentName("Date") // The display name of the processor
-@ComponentDescription("Extracts formatted dates from text")
-@SettingsClass(Date.Settings.class)
 
 /**
  * Annotate dates and date ranges as Temporal/Instant entities. The following examples show the
@@ -56,6 +53,9 @@ import java.util.regex.Pattern;
  * <p>Years on their own will only extracted for the range 1970-2099 to reduce false positives. Two
  * digit years on their own will not be extracted.
  */
+@ComponentName("Date") // The display name of the processor
+@ComponentDescription("Extracts formatted dates from text")
+@SettingsClass(Date.Settings.class)
 public class Date extends AbstractProcessorDescriptor<Date.Processor, Date.Settings> {
 
   @Override
@@ -74,7 +74,7 @@ public class Date extends AbstractProcessorDescriptor<Date.Processor, Date.Setti
 
   public static class Processor extends AbstractTextProcessor {
 
-    private boolean americanDates;
+    private final boolean americanDates;
 
     // Non-capturing as we don't use this information
     private static final String DAYS =
@@ -509,14 +509,14 @@ public class Date extends AbstractProcessorDescriptor<Date.Processor, Date.Setti
       while (m.find()) {
         Year y = DateTimeUtils.asYear(m.group(3));
 
-        Integer n1 = Integer.parseInt(m.group(1));
-        Integer n2 = Integer.parseInt(m.group(2));
+        int n1 = Integer.parseInt(m.group(1));
+        int n2 = Integer.parseInt(m.group(2));
 
-        Integer day;
-        Integer month;
+        int day;
+        int month;
         if (n1 >= 1 && n1 <= 12) {
           // n1 could be a month or a day
-          if (n2 >= 12 && n2 <= 31) {
+          if (n2 > 12 && n2 <= 31) {
             // n2 must be a day
             month = n1;
             day = n2;
@@ -732,7 +732,7 @@ public class Date extends AbstractProcessorDescriptor<Date.Processor, Date.Setti
   public static class Settings implements io.annot8.api.settings.Settings {
     private boolean americanDates = true;
 
-    @Description(" Should we use American dates where applicable (i.e. mm-dd-yy)")
+    @Description("Should we use American dates where applicable (i.e. mm-dd-yy)?")
     public boolean getAmericanDates() {
       return americanDates;
     }

--- a/annot8-components-temporal/src/main/java/io/annot8/components/temporal/processors/Date.java
+++ b/annot8-components-temporal/src/main/java/io/annot8/components/temporal/processors/Date.java
@@ -532,7 +532,7 @@ public class Date extends AbstractProcessorDescriptor<Date.Processor, Date.Setti
             // invalid combination of n1 and n2
             continue;
           }
-        } else if (n1 >= 1 && n1 <= 31) {
+        } else if (n1 > 12 && n1 <= 31) {
           // n1 must be a day
           day = n1;
           if (n2 >= 1 && n2 <= 12) {

--- a/annot8-components-temporal/src/test/java/io/annot8/components/temporal/processors/DateTest.java
+++ b/annot8-components-temporal/src/test/java/io/annot8/components/temporal/processors/DateTest.java
@@ -1,6 +1,8 @@
 /* Annot8 (annot8.io) - Licensed under Apache-2.0. */
 package io.annot8.components.temporal.processors;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import io.annot8.api.annotations.Annotation;
 import io.annot8.api.capabilities.AnnotationCapability;
 import io.annot8.api.capabilities.Capabilities;
@@ -14,9 +16,6 @@ import io.annot8.conventions.AnnotationTypes;
 import io.annot8.conventions.PropertyKeys;
 import io.annot8.testing.testimpl.TestItem;
 import io.annot8.testing.testimpl.content.TestStringContent;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.Year;
@@ -25,8 +24,8 @@ import java.time.temporal.Temporal;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DateTest {
 
@@ -442,27 +441,24 @@ public class DateTest {
 
   @Test
   public void testDecemberDate() {
-    //Test to confirm that a bug has been fixed where December dates were mistakenly identified as American regardless of setting
+    // Test to confirm that a bug has been fixed where December dates were mistakenly identified as
+    // American regardless of setting
 
     try (Processor p = new Date.Processor(false)) {
       Item item = new TestItem();
 
       Text content =
-        item.createContent(TestStringContent.class)
-          .withData("The date is 2/12/2020")
-          .save();
+          item.createContent(TestStringContent.class).withData("The date is 2/12/2020").save();
 
       p.process(item);
 
       AnnotationStore store = content.getAnnotations();
-      List<Annotation> annotations =
-        store
-          .getAll()
-          .collect(Collectors.toList());
+      List<Annotation> annotations = store.getAll().collect(Collectors.toList());
 
       Assertions.assertEquals(1, annotations.size());
 
-      testAnnotationInstant(content, annotations.get(0), "2/12/2020", LocalDate.of(2020, Month.DECEMBER, 2));
+      testAnnotationInstant(
+          content, annotations.get(0), "2/12/2020", LocalDate.of(2020, Month.DECEMBER, 2));
     }
 
     // Now test it in American format
@@ -470,21 +466,17 @@ public class DateTest {
       Item item = new TestItem();
 
       Text content =
-        item.createContent(TestStringContent.class)
-          .withData("The date is 2/12/2020")
-          .save();
+          item.createContent(TestStringContent.class).withData("The date is 2/12/2020").save();
 
       p.process(item);
 
       AnnotationStore store = content.getAnnotations();
-      List<Annotation> annotations =
-        store
-          .getAll()
-          .collect(Collectors.toList());
+      List<Annotation> annotations = store.getAll().collect(Collectors.toList());
 
       Assertions.assertEquals(1, annotations.size());
 
-      testAnnotationInstant(content, annotations.get(0), "2/12/2020", LocalDate.of(2020, Month.FEBRUARY, 12));
+      testAnnotationInstant(
+          content, annotations.get(0), "2/12/2020", LocalDate.of(2020, Month.FEBRUARY, 12));
     }
   }
 

--- a/annot8-components-temporal/src/test/java/io/annot8/components/temporal/processors/DateTest.java
+++ b/annot8-components-temporal/src/test/java/io/annot8/components/temporal/processors/DateTest.java
@@ -1,8 +1,6 @@
 /* Annot8 (annot8.io) - Licensed under Apache-2.0. */
 package io.annot8.components.temporal.processors;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import io.annot8.api.annotations.Annotation;
 import io.annot8.api.capabilities.AnnotationCapability;
 import io.annot8.api.capabilities.Capabilities;
@@ -16,15 +14,19 @@ import io.annot8.conventions.AnnotationTypes;
 import io.annot8.conventions.PropertyKeys;
 import io.annot8.testing.testimpl.TestItem;
 import io.annot8.testing.testimpl.content.TestStringContent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.Year;
 import java.time.YearMonth;
 import java.time.temporal.Temporal;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DateTest {
 
@@ -80,7 +82,7 @@ public class DateTest {
   }
 
   @Test
-  public void testYears() throws Exception {
+  public void testYears() {
 
     try (Processor p = new Date.Processor(false)) {
       Item item = new TestItem();
@@ -115,7 +117,7 @@ public class DateTest {
   }
 
   @Test
-  public void testMonthYears() throws Exception {
+  public void testMonthYears() {
 
     try (Processor p = new Date.Processor(false)) {
       Item item = new TestItem();
@@ -156,7 +158,7 @@ public class DateTest {
   }
 
   @Test
-  public void testDayMonthYears() throws Exception {
+  public void testDayMonthYears() {
 
     try (Processor p = new Date.Processor(false)) {
       Item item = new TestItem();
@@ -218,7 +220,7 @@ public class DateTest {
   }
 
   @Test
-  public void testBadDayMonthYears() throws Exception {
+  public void testBadDayMonthYears() {
 
     try (Processor p = new Date.Processor(false)) {
       Item item = new TestItem();
@@ -244,7 +246,7 @@ public class DateTest {
   }
 
   @Test
-  public void testDates() throws Exception {
+  public void testDates() {
 
     try (Processor p = new Date.Processor(false)) {
       Item item = new TestItem();
@@ -281,7 +283,7 @@ public class DateTest {
   }
 
   @Test
-  public void testAmericanDates() throws Exception {
+  public void testAmericanDates() {
 
     try (Processor p = new Date.Processor(true)) {
       Item item = new TestItem();
@@ -316,7 +318,7 @@ public class DateTest {
   public void testOne(Processor p, String text, String covered, Temporal start, Temporal end) {
     Item item = new TestItem();
 
-    Text content = item.createContent(TestStringContent.class).withData(covered).save();
+    Text content = item.createContent(TestStringContent.class).withData(text).save();
 
     p.process(item);
 
@@ -331,7 +333,7 @@ public class DateTest {
   public void testOne(Processor p, String text, String covered, Temporal instant) {
     Item item = new TestItem();
 
-    Text content = item.createContent(TestStringContent.class).withData(covered).save();
+    Text content = item.createContent(TestStringContent.class).withData(text).save();
 
     p.process(item);
 
@@ -344,7 +346,7 @@ public class DateTest {
   }
 
   @Test
-  public void testMonth() throws Exception {
+  public void testMonth() {
 
     try (Processor p = new Date.Processor(false)) {
       testOne(
@@ -408,7 +410,7 @@ public class DateTest {
   }
 
   @Test
-  public void testYear() throws Exception {
+  public void testYear() {
 
     try (Processor p = new Date.Processor(true)) {
       Item item = new TestItem();
@@ -438,12 +440,60 @@ public class DateTest {
     }
   }
 
+  @Test
+  public void testDecemberDate() {
+    //Test to confirm that a bug has been fixed where December dates were mistakenly identified as American regardless of setting
+
+    try (Processor p = new Date.Processor(false)) {
+      Item item = new TestItem();
+
+      Text content =
+        item.createContent(TestStringContent.class)
+          .withData("The date is 2/12/2020")
+          .save();
+
+      p.process(item);
+
+      AnnotationStore store = content.getAnnotations();
+      List<Annotation> annotations =
+        store
+          .getAll()
+          .collect(Collectors.toList());
+
+      Assertions.assertEquals(1, annotations.size());
+
+      testAnnotationInstant(content, annotations.get(0), "2/12/2020", LocalDate.of(2020, Month.DECEMBER, 2));
+    }
+
+    // Now test it in American format
+    try (Processor p = new Date.Processor(true)) {
+      Item item = new TestItem();
+
+      Text content =
+        item.createContent(TestStringContent.class)
+          .withData("The date is 2/12/2020")
+          .save();
+
+      p.process(item);
+
+      AnnotationStore store = content.getAnnotations();
+      List<Annotation> annotations =
+        store
+          .getAll()
+          .collect(Collectors.toList());
+
+      Assertions.assertEquals(1, annotations.size());
+
+      testAnnotationInstant(content, annotations.get(0), "2/12/2020", LocalDate.of(2020, Month.FEBRUARY, 12));
+    }
+  }
+
   public void testOneRegex(String text, String covered) throws Exception {
     try (Processor p = new Date.Processor(false)) {
 
       Item item = new TestItem();
 
-      Text content = item.createContent(TestStringContent.class).withData(covered).save();
+      Text content = item.createContent(TestStringContent.class).withData(text).save();
 
       p.process(item);
 


### PR DESCRIPTION
Currently there is a bug where dates in December such as 2/12/2020 will always be parsed as American, regardless of the processor settings. This addresses that, and provides a test to confirm it is fixed.