### PR TITLE
Exposes the tesseract processors via the module info

### DIFF
--- a/annot8-components-tesseract/pom.xml
+++ b/annot8-components-tesseract/pom.xml
@@ -30,6 +30,12 @@
             <artifactId>tess4j</artifactId>
             <version>4.5.4</version>
         </dependency>
+
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.6.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/annot8-components-tesseract/src/main/java/io/annot8/components/tesseract/processors/OCR.java
+++ b/annot8-components-tesseract/src/main/java/io/annot8/components/tesseract/processors/OCR.java
@@ -69,7 +69,7 @@ public class OCR extends AbstractProcessorDescriptor<OCR.Processor, OCR.Settings
     private final ITesseract instance;
     private final List<String> extensions;
 
-    public Processor(List<String> extensions, ITesseract tesseract) {
+    private Processor(List<String> extensions, ITesseract tesseract) {
       this.extensions = extensions;
       this.instance = tesseract;
     }

--- a/annot8-components-tesseract/src/main/java/module-info.java
+++ b/annot8-components-tesseract/src/main/java/module-info.java
@@ -8,4 +8,6 @@ module io.annot8.components.tesseract {
   requires java.desktop;
   requires jakarta.json.bind;
   requires io.annot8.conventions;
+
+  exports io.annot8.components.tesseract.processors;
 }

--- a/annot8-components-tesseract/src/test/java/io/annot8/components/tesseract/processors/OCRTest.java
+++ b/annot8-components-tesseract/src/test/java/io/annot8/components/tesseract/processors/OCRTest.java
@@ -14,9 +14,8 @@ import org.junit.jupiter.api.Test;
 
 public class OCRTest {
 
-  // Disabled as it requires tesseract to be installed
   @Test
-  @Disabled
+  @Disabled("Disabled as it requires tesseract to be installed")
   public void test() throws Exception {
     OCR desc = new OCR();
     Processor ocr = desc.createComponent(null, new OCR.Settings());


### PR DESCRIPTION
Was not accessible for use directly.
Made constructor private so the tess4j class is not on the public api and so we don't have to transitively expose that library. 
Add dependency that it complained about - not 100% sure why it wasn't there.