### PR TITLE
Update to use API 1.2.0 and improve module-info

### DIFF
--- a/annot8-components-annotations/src/main/java/io/annot8/components/annotations/processors/MergeAdjacentSpanBounds.java
+++ b/annot8-components-annotations/src/main/java/io/annot8/components/annotations/processors/MergeAdjacentSpanBounds.java
@@ -16,7 +16,13 @@ import io.annot8.common.components.AbstractProcessor;
 import io.annot8.common.components.AbstractProcessorDescriptor;
 import io.annot8.common.components.capabilities.SimpleCapabilities;
 import io.annot8.common.data.bounds.SpanBounds;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @ComponentName("Merge Adjacent Annotations")
@@ -86,7 +92,7 @@ public class MergeAdjacentSpanBounds
                   if (annotations.size() < 2) continue;
 
                   Annotation aCurr = annotations.get(0);
-                  for (int i = 1; i < annotations.size() - 1; i++) {
+                  for (int i = 1; i < annotations.size(); i++) {
                     Annotation a2 = annotations.get(i);
 
                     SpanBounds s1 = aCurr.getBounds(SpanBounds.class).get();

--- a/annot8-components-annotations/src/main/java/module-info.java
+++ b/annot8-components-annotations/src/main/java/module-info.java
@@ -1,8 +1,11 @@
-module annot8.components.annotations {
+module io.annot8.components.annotations {
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
   requires io.annot8.common.data;
   requires jakarta.json.bind;
   requires org.slf4j;
   requires io.annot8.components.base;
   requires io.annot8.conventions;
+
+  exports io.annot8.components.annotations.processors;
 }

--- a/annot8-components-annotations/src/test/java/io/annot8/components/annotations/processors/MergeAdjacentSpanBoundsTest.java
+++ b/annot8-components-annotations/src/test/java/io/annot8/components/annotations/processors/MergeAdjacentSpanBoundsTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 public class MergeAdjacentSpanBoundsTest {
   @Test
-  public void test() {
+  public void testWithTypeFilter() {
     Item item = new TestItem();
 
     TestStringContent c =
@@ -39,11 +39,8 @@ public class MergeAdjacentSpanBoundsTest {
         .withBounds(new SpanBounds(5, 8))
         .withProperty("surname", true)
         .save(); // Doe
-    c.getAnnotations()
-        .create()
-        .withType("person")
-        .withBounds(new SpanBounds(17, 28))
-        .save(); // Ms. Alice B
+    // Ms.Alice B
+    c.getAnnotations().create().withType("person").withBounds(new SpanBounds(17, 28)).save();
     c.getAnnotations()
         .create()
         .withType("person")
@@ -98,5 +95,82 @@ public class MergeAdjacentSpanBoundsTest {
         time.stream().map(a -> a.getBounds().getData(c).get()).collect(Collectors.toList());
     assertTrue(timeValues.contains("last"));
     assertTrue(timeValues.contains("week"));
+  }
+
+  @Test
+  public void testIncludesLastElement() {
+    Item item = new TestItem();
+
+    TestStringContent c =
+        item.createContent(TestStringContent.class)
+            .withData("John Doe visited Ms.\tAlice Bethany  Cox with Jane last week.")
+            .save();
+
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(0, 4))
+        .withProperty("surname", false)
+        .save(); // John
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(5, 8))
+        .withProperty("surname", true)
+        .save(); // Doe
+    // Ms.Alice B
+    c.getAnnotations().create().withType("person").withBounds(new SpanBounds(17, 28)).save();
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(21, 26))
+        .save(); // Alice
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(27, 34))
+        .save(); // Bethany
+    c.getAnnotations().create().withType("person").withBounds(new SpanBounds(36, 39)).save(); // Cox
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(45, 49))
+        .save(); // Jane
+    c.getAnnotations().create().withType("time").withBounds(new SpanBounds(50, 54)).save(); // last
+    c.getAnnotations().create().withType("time").withBounds(new SpanBounds(55, 59)).save(); // week
+
+    MergeAdjacentSpanBounds.Settings settings = new MergeAdjacentSpanBounds.Settings();
+    settings.setAllowableSeparators(Set.of(" ", "\t", "-"));
+    settings.setMaxRepeatableSeparators(-1);
+
+    Processor p = new MergeAdjacentSpanBounds.Processor(settings);
+
+    ProcessorResponse pr = p.process(item);
+    assertEquals(ProcessorResponse.ok(), pr);
+
+    Content<?> cProcessed = item.getContents().findFirst().get();
+
+    List<Annotation> persons =
+        cProcessed.getAnnotations().getByType("person").collect(Collectors.toList());
+    List<Annotation> time =
+        cProcessed.getAnnotations().getByType("time").collect(Collectors.toList());
+
+    assertEquals(3, persons.size());
+    assertEquals(1, time.size());
+
+    List<String> personNames =
+        persons.stream().map(a -> a.getBounds().getData(c).get()).collect(Collectors.toList());
+    assertTrue(personNames.contains("John Doe"));
+    assertTrue(personNames.contains("Ms.\tAlice Bethany  Cox"));
+    assertTrue(personNames.contains("Jane"));
+
+    List<Annotation> surnameProp =
+        persons.stream().filter(a -> a.getProperties().has("surname")).collect(Collectors.toList());
+    assertEquals(1, surnameProp.size());
+    assertEquals(true, surnameProp.get(0).getProperties().get("surname").get());
+
+    List<String> timeValues =
+        time.stream().map(a -> a.getBounds().getData(c).get()).collect(Collectors.toList());
+    assertTrue(timeValues.contains("last week"));
   }
 }

--- a/annot8-components-audio/src/main/java/module-info.java
+++ b/annot8-components-audio/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module annot8.components.audio {
+module io.annot8.components.audio {
   requires io.annot8.api;
   requires io.annot8.common.components;
   requires io.annot8.common.data;

--- a/annot8-components-base-text/src/main/java/module-info.java
+++ b/annot8-components-base-text/src/main/java/module-info.java
@@ -1,8 +1,9 @@
 module io.annot8.components.base.text {
+  requires transitive io.annot8.api;
   requires io.annot8.common.data;
   requires io.annot8.common.components;
   requires io.annot8.components.base;
-  requires io.annot8.components.stopwords;
+  requires transitive io.annot8.components.stopwords;
   requires io.annot8.conventions;
   requires jakarta.json.bind;
 

--- a/annot8-components-comms/src/main/java/module-info.java
+++ b/annot8-components-comms/src/main/java/module-info.java
@@ -1,10 +1,10 @@
 module io.annot8.components.comms {
-  requires io.annot8.api;
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
   requires io.annot8.common.data;
   requires io.annot8.components.base.text;
   requires io.annot8.conventions;
-  requires libphonenumber;
+  requires transitive libphonenumber;
 
   exports io.annot8.components.comms.processors;
 }

--- a/annot8-components-db/src/main/java/module-info.java
+++ b/annot8-components-db/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module io.annot8.components.db {
   requires transitive io.annot8.components.base;
   requires io.annot8.common.components;
-  requires io.annot8.common.data;
+  requires transitive io.annot8.common.data;
   requires com.google.common;
   requires sqlite.jdbc;
   requires java.sql;

--- a/annot8-components-documents/src/main/java/io/annot8/components/documents/processors/DocumentExtractor.java
+++ b/annot8-components-documents/src/main/java/io/annot8/components/documents/processors/DocumentExtractor.java
@@ -119,8 +119,8 @@ public class DocumentExtractor
 
     @Override
     public boolean acceptFile(FileContent file) {
-      DocumentType documentType =
-          DocumentType.PLAIN_TEXT; // Accepts any document, so use it as our default
+      DocumentType documentType = DocumentType.PLAIN_TEXT; // Accepts any document, so use it as our
+      // default
 
       if (docProcessor.acceptFile(file)) {
         documentType = DocumentType.DOC;
@@ -146,8 +146,8 @@ public class DocumentExtractor
 
     @Override
     public boolean acceptInputStream(InputStreamContent inputStream) {
-      DocumentType documentType =
-          DocumentType.PLAIN_TEXT; // Accepts any document, so use it as our default
+      DocumentType documentType = DocumentType.PLAIN_TEXT; // Accepts any document, so use it as our
+      // default
 
       if (docProcessor.acceptInputStream(inputStream)) {
         documentType = DocumentType.DOC;
@@ -345,7 +345,7 @@ public class DocumentExtractor
     }
   }
 
-  protected static class DocumentObjectWithType {
+  public static class DocumentObjectWithType {
     private final Object document;
     private final DocumentType type;
 
@@ -363,7 +363,7 @@ public class DocumentExtractor
     }
   }
 
-  protected enum DocumentType {
+  public enum DocumentType {
     DOC,
     DOCX,
     HTML,

--- a/annot8-components-documents/src/main/java/module-info.java
+++ b/annot8-components-documents/src/main/java/module-info.java
@@ -3,18 +3,18 @@ module io.annot8.components.documents {
 
   requires transitive io.annot8.api;
   requires io.annot8.common.components;
-  requires io.annot8.common.data;
+  requires transitive io.annot8.common.data;
   requires io.annot8.common.utils;
   requires io.annot8.conventions;
-  requires java.desktop;
+  requires transitive java.desktop;
   requires metadata.extractor;
   requires odfdom.java;
   requires org.apache.pdfbox;
-  requires org.jsoup;
+  requires transitive org.jsoup;
   requires org.slf4j;
   requires org.apache.poi.poi;
-  requires org.apache.poi.ooxml;
-  requires org.apache.poi.scratchpad;
+  requires transitive org.apache.poi.ooxml;
+  requires transitive org.apache.poi.scratchpad;
   requires org.apache.commons.compress;
   requires java.net.http;
   requires javatuples;

--- a/annot8-components-files/src/main/java/module-info.java
+++ b/annot8-components-files/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 module io.annot8.components.files {
   requires transitive io.annot8.api;
-  requires io.annot8.common.data;
+  requires transitive io.annot8.common.data;
   requires io.annot8.conventions;
   requires io.annot8.common.components;
   requires transitive io.annot8.components.base;
@@ -20,5 +20,5 @@ module io.annot8.components.files {
   requires org.apache.commons.text;
   requires fastcsv;
   requires org.apache.commons.compress;
-  requires simplemagic;
+  requires transitive simplemagic;
 }

--- a/annot8-components-gazetteers/src/main/java/module-info.java
+++ b/annot8-components-gazetteers/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module io.annot8.components.gazetteers {
-  requires io.annot8.api;
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
   requires io.annot8.common.data;
   requires io.annot8.components.base.text;

--- a/annot8-components-groups/src/main/java/module-info.java
+++ b/annot8-components-groups/src/main/java/module-info.java
@@ -1,7 +1,10 @@
-module annot8.components.groups {
+module io.annot8.components.groups {
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
   requires io.annot8.common.data;
   requires io.annot8.components.base;
   requires jakarta.json.bind;
   requires org.slf4j;
+
+  exports io.annot8.components.groups.processors;
 }

--- a/annot8-components-image/src/main/java/module-info.java
+++ b/annot8-components-image/src/main/java/module-info.java
@@ -1,6 +1,7 @@
-module annot8.components.image {
+module io.annot8.components.image {
+  requires transitive io.annot8.api;
   requires io.annot8.components.base;
-  requires io.annot8.common.data;
+  requires transitive io.annot8.common.data;
   requires metadata.extractor;
   requires io.annot8.common.components;
   requires io.annot8.conventions;

--- a/annot8-components-items/src/main/java/module-info.java
+++ b/annot8-components-items/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module io.annot8.components.items {
-  requires io.annot8.api;
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
-  requires io.annot8.common.data;
+  requires transitive io.annot8.common.data;
   requires io.annot8.components.base;
   requires io.annot8.conventions;
   requires jakarta.json.bind;

--- a/annot8-components-kafka/src/main/java/module-info.java
+++ b/annot8-components-kafka/src/main/java/module-info.java
@@ -1,8 +1,9 @@
 module annot8.components.kafka {
+  requires transitive io.annot8.api;
   requires io.annot8.common.data;
   requires io.annot8.conventions;
   requires io.annot8.common.components;
-  requires kafka.clients;
+  requires transitive kafka.clients;
 
   exports io.annot8.components.kafka.sources;
 }

--- a/annot8-components-mongo/src/main/java/module-info.java
+++ b/annot8-components-mongo/src/main/java/module-info.java
@@ -1,13 +1,14 @@
 module io.annot8.components.mongo {
+  requires transitive io.annot8.api;
   requires io.annot8.common.data;
   requires io.annot8.components.base;
   requires io.annot8.conventions;
   requires com.google.common;
   requires com.fasterxml.jackson.databind;
   requires com.fasterxml.jackson.core;
-  requires io.annot8.implementations.support;
+  requires transitive io.annot8.implementations.support;
   requires io.annot8.common.components;
-  requires org.mongodb.bson;
+  requires transitive org.mongodb.bson;
   requires org.mongodb.driver.core;
   requires org.mongodb.driver.sync.client;
 

--- a/annot8-components-opencv/src/main/java/module-info.java
+++ b/annot8-components-opencv/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module io.annot8.components.opencv {
+  requires transitive io.annot8.api;
+  requires transitive io.annot8.common.data;
+  requires io.annot8.conventions;
+  requires io.annot8.common.components;
+  requires java.desktop;
+  requires opencv;
+
+  exports io.annot8.components.opencv.processors;
+}

--- a/annot8-components-people/src/main/java/module-info.java
+++ b/annot8-components-people/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module annot8.components.people {
-  requires io.annot8.api;
+module io.annot8.components.people {
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
   requires io.annot8.common.data;
   requires io.annot8.components.base.text;

--- a/annot8-components-print/src/main/java/module-info.java
+++ b/annot8-components-print/src/main/java/module-info.java
@@ -3,7 +3,7 @@ open module io.annot8.components.print {
   requires io.annot8.common.data;
   requires io.annot8.common.components;
   requires io.annot8.components.base.text;
-  requires org.slf4j;
+  requires transitive org.slf4j;
 
   exports io.annot8.components.print.processors;
 }

--- a/annot8-components-properties/src/main/java/module-info.java
+++ b/annot8-components-properties/src/main/java/module-info.java
@@ -1,8 +1,11 @@
 module io.annot8.components.properties {
+  requires transitive io.annot8.api;
   requires io.annot8.common.data;
   requires io.annot8.common.components;
   requires org.slf4j;
   requires jakarta.json.bind;
   requires io.annot8.components.base;
   requires io.annot8.conventions;
+
+  exports io.annot8.components.properties.processors;
 }

--- a/annot8-components-quantities/src/main/java/module-info.java
+++ b/annot8-components-quantities/src/main/java/module-info.java
@@ -4,7 +4,7 @@ open module io.annot8.components.quantities {
   requires io.annot8.conventions;
   requires transitive io.annot8.components.base.text;
   requires org.slf4j;
-  requires io.annot8.common.components;
+  requires transitive io.annot8.common.components;
 
   exports io.annot8.components.quantities.processors;
 }

--- a/annot8-components-spacy/src/main/java/module-info.java
+++ b/annot8-components-spacy/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 module io.annot8.components.spacy {
   requires transitive io.annot8.api;
-  requires io.annot8.common.data;
+  requires transitive io.annot8.common.data;
   requires io.annot8.components.base.text;
   requires io.annot8.conventions;
   requires io.annot8.common.utils;

--- a/annot8-components-stopwords/src/main/java/module-info.java
+++ b/annot8-components-stopwords/src/main/java/module-info.java
@@ -1,7 +1,8 @@
 module io.annot8.components.stopwords {
-  requires io.annot8.api;
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
   requires io.annot8.common.data;
 
   exports io.annot8.components.stopwords.resources;
+  exports io.annot8.components.stopwords.processors;
 }

--- a/annot8-components-temporal/src/main/java/module-info.java
+++ b/annot8-components-temporal/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module io.annot8.components.temporal {
-  requires io.annot8.api;
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
-  requires io.annot8.common.data;
+  requires transitive io.annot8.common.data;
   requires io.annot8.components.base.text;
   requires io.annot8.conventions;
   requires jakarta.json.bind;

--- a/annot8-components-text/src/main/java/module-info.java
+++ b/annot8-components-text/src/main/java/module-info.java
@@ -1,9 +1,9 @@
 open module io.annot8.components.text {
   requires transitive io.annot8.api;
-  requires io.annot8.common.data;
+  requires transitive io.annot8.common.data;
   requires io.annot8.components.base.text;
   requires io.annot8.conventions;
-  requires lingua;
+  requires transitive lingua;
   requires io.annot8.common.components;
   requires jakarta.json.bind;
 

--- a/annot8-components-tika/src/main/java/module-info.java
+++ b/annot8-components-tika/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module io.annot8.components.tika {
+  requires transitive io.annot8.api;
+  requires io.annot8.common.data;
+  requires io.annot8.common.components;
+  requires java.xml;
+  requires tika.core;
+
+  exports io.annot8.components.tika.processors;
+}

--- a/annot8-components-translation/src/main/java/module-info.java
+++ b/annot8-components-translation/src/main/java/module-info.java
@@ -5,7 +5,7 @@ open module io.annot8.components.translation {
   requires io.annot8.components.base.text;
   requires io.annot8.conventions;
   requires io.annot8.common.components;
-  requires connector.api;
+  requires transitive connector.api;
 
   exports io.annot8.components.translation.processors;
 }

--- a/annot8-components-vehicles/src/main/java/module-info.java
+++ b/annot8-components-vehicles/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module io.annot8.components.vehicles {
-  requires io.annot8.api;
+  requires transitive io.annot8.api;
   requires io.annot8.common.components;
   requires io.annot8.common.data;
   requires io.annot8.components.base.text;

--- a/annot8-components-wordnet/src/main/java/module-info.java
+++ b/annot8-components-wordnet/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module io.annot8.components.wordnet {
+  requires transitive io.annot8.api;
+  requires transitive io.annot8.common.data;
+  requires io.annot8.components.base.text;
+  requires io.annot8.common.components;
+  requires io.annot8.conventions;
+  requires transitive extjwnl;
+
+  exports io.annot8.components.wordnet.processors;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <!-- Annot8 versions -->
-    <annot8-api.version>1.1</annot8-api.version>
-    <annot8-implementation.version>1.1.0</annot8-implementation.version>
+    <annot8-api.version>1.2.0</annot8-api.version>
+    <annot8-implementation.version>1.2.0</annot8-implementation.version>
 
     <!-- Utils -->
     <guava.version>30.1.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <!-- Annot8 versions -->
-    <annot8-api.version>1.2.0</annot8-api.version>
+    <annot8-api.version>1.2</annot8-api.version>
     <annot8-implementation.version>1.2.0</annot8-implementation.version>
 
     <!-- Utils -->


### PR DESCRIPTION
Standardise module names (to include the io)
Add transitive to dependencies were classes are on the API surface
Adds some missing module info files
Made some methods/constructors private to avoid transitive dependencies.
Could not add for elasticsearch due to split package.