### PR TITLE
Fixes bug in MergeAdjacentSpanBounds

### DIFF
--- a/annot8-components-annotations/src/main/java/io/annot8/components/annotations/processors/MergeAdjacentSpanBounds.java
+++ b/annot8-components-annotations/src/main/java/io/annot8/components/annotations/processors/MergeAdjacentSpanBounds.java
@@ -16,7 +16,13 @@ import io.annot8.common.components.AbstractProcessor;
 import io.annot8.common.components.AbstractProcessorDescriptor;
 import io.annot8.common.components.capabilities.SimpleCapabilities;
 import io.annot8.common.data.bounds.SpanBounds;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @ComponentName("Merge Adjacent Annotations")
@@ -86,7 +92,7 @@ public class MergeAdjacentSpanBounds
                   if (annotations.size() < 2) continue;
 
                   Annotation aCurr = annotations.get(0);
-                  for (int i = 1; i < annotations.size() - 1; i++) {
+                  for (int i = 1; i < annotations.size(); i++) {
                     Annotation a2 = annotations.get(i);
 
                     SpanBounds s1 = aCurr.getBounds(SpanBounds.class).get();

--- a/annot8-components-annotations/src/test/java/io/annot8/components/annotations/processors/MergeAdjacentSpanBoundsTest.java
+++ b/annot8-components-annotations/src/test/java/io/annot8/components/annotations/processors/MergeAdjacentSpanBoundsTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 public class MergeAdjacentSpanBoundsTest {
   @Test
-  public void test() {
+  public void testWithTypeFilter() {
     Item item = new TestItem();
 
     TestStringContent c =
@@ -39,11 +39,8 @@ public class MergeAdjacentSpanBoundsTest {
         .withBounds(new SpanBounds(5, 8))
         .withProperty("surname", true)
         .save(); // Doe
-    c.getAnnotations()
-        .create()
-        .withType("person")
-        .withBounds(new SpanBounds(17, 28))
-        .save(); // Ms. Alice B
+    // Ms.Alice B
+    c.getAnnotations().create().withType("person").withBounds(new SpanBounds(17, 28)).save();
     c.getAnnotations()
         .create()
         .withType("person")
@@ -98,5 +95,82 @@ public class MergeAdjacentSpanBoundsTest {
         time.stream().map(a -> a.getBounds().getData(c).get()).collect(Collectors.toList());
     assertTrue(timeValues.contains("last"));
     assertTrue(timeValues.contains("week"));
+  }
+
+  @Test
+  public void testIncludesLastElement() {
+    Item item = new TestItem();
+
+    TestStringContent c =
+        item.createContent(TestStringContent.class)
+            .withData("John Doe visited Ms.\tAlice Bethany  Cox with Jane last week.")
+            .save();
+
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(0, 4))
+        .withProperty("surname", false)
+        .save(); // John
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(5, 8))
+        .withProperty("surname", true)
+        .save(); // Doe
+    // Ms.Alice B
+    c.getAnnotations().create().withType("person").withBounds(new SpanBounds(17, 28)).save();
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(21, 26))
+        .save(); // Alice
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(27, 34))
+        .save(); // Bethany
+    c.getAnnotations().create().withType("person").withBounds(new SpanBounds(36, 39)).save(); // Cox
+    c.getAnnotations()
+        .create()
+        .withType("person")
+        .withBounds(new SpanBounds(45, 49))
+        .save(); // Jane
+    c.getAnnotations().create().withType("time").withBounds(new SpanBounds(50, 54)).save(); // last
+    c.getAnnotations().create().withType("time").withBounds(new SpanBounds(55, 59)).save(); // week
+
+    MergeAdjacentSpanBounds.Settings settings = new MergeAdjacentSpanBounds.Settings();
+    settings.setAllowableSeparators(Set.of(" ", "\t", "-"));
+    settings.setMaxRepeatableSeparators(-1);
+
+    Processor p = new MergeAdjacentSpanBounds.Processor(settings);
+
+    ProcessorResponse pr = p.process(item);
+    assertEquals(ProcessorResponse.ok(), pr);
+
+    Content<?> cProcessed = item.getContents().findFirst().get();
+
+    List<Annotation> persons =
+        cProcessed.getAnnotations().getByType("person").collect(Collectors.toList());
+    List<Annotation> time =
+        cProcessed.getAnnotations().getByType("time").collect(Collectors.toList());
+
+    assertEquals(3, persons.size());
+    assertEquals(1, time.size());
+
+    List<String> personNames =
+        persons.stream().map(a -> a.getBounds().getData(c).get()).collect(Collectors.toList());
+    assertTrue(personNames.contains("John Doe"));
+    assertTrue(personNames.contains("Ms.\tAlice Bethany  Cox"));
+    assertTrue(personNames.contains("Jane"));
+
+    List<Annotation> surnameProp =
+        persons.stream().filter(a -> a.getProperties().has("surname")).collect(Collectors.toList());
+    assertEquals(1, surnameProp.size());
+    assertEquals(true, surnameProp.get(0).getProperties().get("surname").get());
+
+    List<String> timeValues =
+        time.stream().map(a -> a.getBounds().getData(c).get()).collect(Collectors.toList());
+    assertTrue(timeValues.contains("last week"));
   }
 }


### PR DESCRIPTION
Missed the last annotation is the comparison.
Changes the loop bounds to fix.
Added tests.