### PR TITLE
Separate clean options

### DIFF
--- a/annot8-components-text/src/main/java/io/annot8/components/text/processors/Clean.java
+++ b/annot8-components-text/src/main/java/io/annot8/components/text/processors/Clean.java
@@ -74,6 +74,9 @@ public class Clean extends AbstractProcessorDescriptor<Clean.Processor, Clean.Se
       if (settings.isRemoveSingleNewLines()) {
         clean = clean.replaceAll(SPLIT_LINES, "-");
         clean = clean.replaceAll(SINGLE_NEW_LINES, " ");
+      }
+
+      if (settings.isRemoveRepeatedNewLines()) {
         clean = clean.replaceAll(REPEATED_NEW_LINES, "\n\n");
       }
 
@@ -109,6 +112,7 @@ public class Clean extends AbstractProcessorDescriptor<Clean.Processor, Clean.Se
     private boolean trim = true;
     private boolean trimLines = true;
     private boolean removeSingleNewLines = true;
+    private boolean removeRepeatedNewLines = true;
     private boolean replaceSmartCharacters = true;
     private boolean removeRepeatedWhitespace = true;
     private boolean copyProperties = true;
@@ -152,16 +156,25 @@ public class Clean extends AbstractProcessorDescriptor<Clean.Processor, Clean.Se
       this.trimLines = trimLines;
     }
 
-    @Description(
-        value =
-            "Should single new lines within text be removed? This will also reduce repeated new lines to 2 new lines.",
-        defaultValue = "true")
+    @Description(value = "Should single new lines within text be removed?", defaultValue = "true")
     public boolean isRemoveSingleNewLines() {
       return removeSingleNewLines;
     }
 
     public void setRemoveSingleNewLines(boolean removeSingleNewLines) {
       this.removeSingleNewLines = removeSingleNewLines;
+    }
+
+    @Description(
+        value =
+            "Should repeated new lines within text be removed? This will reduce repeated new lines to 2 new lines.",
+        defaultValue = "true")
+    public boolean isRemoveRepeatedNewLines() {
+      return removeRepeatedNewLines;
+    }
+
+    public void setRemoveRepeatedNewLines(boolean removeRepeatedNewLines) {
+      this.removeRepeatedNewLines = removeRepeatedNewLines;
     }
 
     @Description(

--- a/annot8-components-text/src/test/java/io/annot8/components/text/processors/CleanTest.java
+++ b/annot8-components-text/src/test/java/io/annot8/components/text/processors/CleanTest.java
@@ -134,4 +134,25 @@ public class CleanTest {
     assertEquals(
         "en", item.getContents(Text.class).findFirst().get().getProperties().get("lang").get());
   }
+
+  @Test
+  public void testCanRetainSingleSpacesButReduceRepeatedNewLines() {
+    Clean.Settings s = getFalseSettings();
+    s.setRemoveSingleNewLines(false);
+    s.setRemoveRepeatedNewLines(true);
+
+    Processor p = new Clean.Processor(s);
+    Item item = new TestItem();
+
+    item.createContent(TestStringContent.class)
+        .withData("Hello\neveryone;\n\n\n\nHello world!\n")
+        .save();
+
+    p.process(item);
+    assertEquals(1L, item.getContents().count());
+
+    assertEquals(
+        "Hello\neveryone;\n\nHello world!\n",
+        item.getContents(Text.class).findFirst().get().getData());
+  }
 }


### PR DESCRIPTION
Separates the clean options for remove single line and remove repeated lines.
Useful for keeping the new lines (say from ocr) but removing extra spaces.

As all set to true, default behaviour remains the same.